### PR TITLE
Add argument to function call

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -191,7 +191,7 @@ var App = AbstractApp.extend({
    * @returns {App}
    */
   addChildApp: function(appName, AppClass, options) {
-    this._ensureAppIsUnique();
+    this._ensureAppIsUnique(appName);
 
     var childApp = this.buildApp(AppClass, options);
 


### PR DESCRIPTION
We were not sending appName as an argument when calling _ensureAppIsUnique. This resolves #42.