### PR TITLE
Override listenToOnce

### DIFF
--- a/src/abstract-app.js
+++ b/src/abstract-app.js
@@ -264,8 +264,25 @@ var AbstractApp = StateClass.extend({
       this._runningListeningTo.push(arguments);
     }
     return StateClass.prototype.listenTo.apply(this, arguments);
-  }
+  },
 
+  /**
+   * Overrides `Backbone.Event.listenToOnce()`
+   * If this `App` is running it will register the listener for removal `onStop`
+   *
+   * @public
+   * @method listenToOnce
+   * @memberOf AbstractApp
+   * @returns {AbstractApp}
+   */
+  listenToOnce: function(){
+    if(this._isRunning) {
+      this._runningListeningTo = (this._runningListeningTo || []);
+      this._runningListeningTo.push(arguments);
+    }
+
+    return StateClass.prototype.listenToOnce.apply(this, arguments);
+  }
 });
 
 export default AbstractApp;


### PR DESCRIPTION
Apparently `listenToOnce` doesn't call our overridden `listenTo`.

This covers that, if for some reason this changes in a future Bb release, this ought to still work, it just might be redundant.

Resolves bug found in #51 