### PR TITLE
mixin state model as stateModel for Component

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -209,7 +209,7 @@ var Component = StateClass.extend({
   mixinOptions: function(options){
     var viewOptions = _.result(this, 'viewOptions');
 
-    return _.extend({ model: this.getState() }, viewOptions, options);
+    return _.extend({ stateModel: this.getState() }, viewOptions, options);
   },
 
   /**


### PR DESCRIPTION
Things get complicated if you want your view component to render a model.. there's no reason why the component should default to the state model

Resolved #65 