### PR TITLE
Destroy listener should call internal destroy

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -135,7 +135,7 @@ var Component = StateClass.extend({
 
     // Destroy the component if the region is emptied because
     // it destroys the view
-    this.listenTo(this.region, 'empty', this.destroy);
+    this.listenTo(this.region, 'empty', this._destroy);
 
     return this;
   },


### PR DESCRIPTION
The public `destroy` empties the region and forces the destroy.