### PR TITLE
Move the triggerMethod('start'.. to an overrideable method

### DIFF
--- a/src/abstract-app.js
+++ b/src/abstract-app.js
@@ -131,7 +131,6 @@ var AbstractApp = StateClass.extend({
    * @memberOf AbstractApp
    * @param {Object} [options] - Settings for the App passed through to events
    * @event AbstractApp#before:start - passes options
-   * @event AbstractApp#start - passes options
    * @returns {AbstractApp}
    */
   start: function(options) {
@@ -145,9 +144,24 @@ var AbstractApp = StateClass.extend({
 
     this._isRunning = true;
 
-    this.triggerMethod('start', options);
+    this.triggerStart(options);
 
     return this;
+  },
+
+  /**
+   * Triggers start event.
+   * Override to introduce async start
+   *
+   * @public
+   * @method triggerStart
+   * @memberOf AbstractApp
+   * @param {Object} [options] - Settings for the App passed through to events
+   * @event AbstractApp#start - passes options
+   * @returns
+   */
+  triggerStart: function(options) {
+    this.triggerMethod('start', options);
   },
 
   /**


### PR DESCRIPTION
Partially resolves #76 

@brentli1 I think I'd like to try and squeeze this into `0.2.0` I tried implementing this tonight for our factor pathways app and it cleans up a bunch of stuff.  Unfortunately I still can't add tests or docs on this commit since that stuff is not on develop yet.

This allows the user to add async functionality
```js
triggerStart: function(options){
  //this.triggerMethod('start', options);
  this.on('sync:data', _.partial(this.triggerMethod, 'start', options));

  this._fetchData(options);
},
_fetchData: function(options){
  $.when(this.beforeStart(options)).then(_.bind(this.trigger, this, 'sync:data'));
},
beforeStart: function(options){
  return $.Deferred().resolve();
}
```