### PR TITLE
Export Toolkit as global var

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "babelBoilerplateOptions": {
     "entryFileName": "marionette.toolkit",
-    "exportVarName": "null",
+    "exportVarName": "Marionette.Toolkit",
     "mochaGlobals": [
       "stub",
       "spy",

--- a/src/marionette.toolkit.js
+++ b/src/marionette.toolkit.js
@@ -22,3 +22,5 @@ Toolkit.StateClass = StateClass;
 Toolkit.App = App;
 
 Toolkit.Component = Component;
+
+export default Toolkit;


### PR DESCRIPTION
Resolves #102 

However one issue here is that `Toolkit` will get attached to `Marionette`, but it will also get attached to `window` if not using require..  Not sure we really want the `global.Toolkit = `

You'll find Backbone.Radio also exports Radio, but doesn't attach to the window if loaded old school.

Suboptimal there.  At the moment I think it may be a limitation of the boilerplate:
https://github.com/babel/babel-library-boilerplate/issues/131