### PR TITLE
Add name to childApp instance and getName method

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -9,6 +9,7 @@
   * [App `buildApp`](#app-buildapp)
   * [App `addChildApp`](#app-addchildapp)
   * [App `addChildApps`](#app-addchildapps)
+  * [App `getName`](#app-getName)
   * [App `getChildApp`](#app-getchildapp)
   * [App `getChildApps`](#app-getchildapps)
   * [App `removeChildApp`](#app-removechildapp)
@@ -119,6 +120,30 @@ myApp.getChildApp('main');        //=> 'main' app instance
 var navApp = myApp.getChildApp('navigation');  //=> 'navigation' app instance
 navApp.getOption('fooOption'); //=> true
 myApp.getChildApp('footer'); //=> 'footer' app instance
+```
+
+### App `getName`
+
+An App's name can be retrieved from the App
+instance calling the `getName` method on the
+instance. If the app is a childApp then the
+app name will be returned, however if an app
+is not a childApp or is a parentApp `undefined`
+will be returned.
+
+```js
+var myApp = new Marionette.Toolkit.App();
+
+myApp.addChildApp('bar', Marionette.Toolkit.App);
+var barAppName = myApp.getChildApp('bar').getName();
+
+// logs bar
+console.log(barAppName);
+
+var myAppName = myApp.getName();
+
+// logs undefined
+console.log(myAppName);
 ```
 
 ### App `getChildApp`

--- a/src/app.js
+++ b/src/app.js
@@ -216,6 +216,8 @@ var App = AbstractApp.extend({
       });
     }
 
+    childApp._name = appName;
+
     this._childApps[appName] = childApp;
 
     // When the app is destroyed remove the cached app.
@@ -227,6 +229,19 @@ var App = AbstractApp.extend({
 
     return childApp;
   },
+
+  /**
+   * Returns registered child `App`s name
+   *
+   * @public
+   * @method getName
+   * @memberOf App
+   * @returns {String}
+   */
+  getName: function() {
+    return this._name;
+  },
+
 
   /**
    * Returns registered child `App`s array
@@ -263,6 +278,7 @@ var App = AbstractApp.extend({
    * @returns {App}
    */
   _removeChildApp: function(appName) {
+    delete this._childApps[appName]._name;
     delete this._childApps[appName];
   },
 

--- a/test/unit/app-child-manager.spec.js
+++ b/test/unit/app-child-manager.spec.js
@@ -178,6 +178,34 @@ describe('App Manager', function() {
     it('should be called three times', function() {
       expect(this.myApp.addChildApp.callCount === 3).to.be.true;
     });
+
+    it('should assign the childApp name to the passed in appName', function(){
+      expect(this.myApp.addChildApp('cA4', Marionette.Toolkit.App)).to.have.property('_name', 'cA4');
+    });
+
+  });
+
+  describe('getName', function(){
+    beforeEach(function() {
+      this.sinon.spy(this.myApp, 'addChildApp');
+
+      this.myApp.addChildApps(this.childApps);
+    });
+
+    it('should return the name of the childApp', function(){
+      expect(this.myApp.getChildApp('cA1').getName()).to.equal('cA1');
+    });
+
+    it('should return undefined for an app that is not a child app', function(){
+      expect(this.myApp.getName()).to.be.undefined;
+    });
+
+    it('should return undefined if a childApp has been removed from parent', function(){
+      var childApp = this.myApp.getChildApp('cA3');
+      this.myApp.removeChildApp('cA3');
+
+      expect(childApp.getName()).to.be.undefined;
+    });
   });
 
   describe('buildApp', function() {


### PR DESCRIPTION
With this, now childApp instances will have their name attached to instance itself. A appName can be retrieved by using the new getName method. If an app is a childApp then the appName will be returned. However if the app is not a childApp or is a parentApp then undefined will be returned. This commit includes src code, tests and docs. This resolves  #103