### PR TITLE
Toolkit module builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Marionette.Toolkit is a collection of opinionated extensions for
 for complex large scale application problems.  This toolkit was
 built from scripts open sourced from [RoundingWell.com](http://roundingwell.com).
 
+In addition to the full library, each element in Toolkit is available as it's own [npm module](marionette.toolkit-modularized).
 
 ## Documentation
   [StateClass](./docs/state-class.md) - `Marionette.Object` with a `Backbone.Model` for keeping state.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "babel": "^4.3.0",
     "babelify": "^5.0.3",
+    "bluebird": "^2.9.27",
     "browserify": "^8.1.1",
     "chai": "^2.0.0",
     "del": "^1.1.1",
@@ -54,6 +55,7 @@
     "gulp-plumber": "^0.6.6",
     "gulp-rename": "^1.2.0",
     "gulp-sourcemaps": "^1.3.0",
+    "gulp-template": "^3.0.0",
     "gulp-uglifyjs": "^0.6.0",
     "isparta": "^2.2.0",
     "jquery": "~2.1.1",
@@ -70,6 +72,11 @@
   "babelBoilerplateOptions": {
     "entryFileName": "marionette.toolkit",
     "exportVarName": "Marionette.Toolkit",
+    "exportPackageNames": {
+      "App": "app",
+      "Component": "component",
+      "StateClass": "state-class"
+    },
     "mochaGlobals": [
       "stub",
       "spy",

--- a/packages/LICENSE
+++ b/packages/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 RoundingWell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,20 @@
+# Marionette.Toolkit.<%=exportVarName%> v<%=version%>
+
+[Marionette.Toolkit](https://github.com/RoundingWellOS/marionette.toolkit)'s `<%=exportVarName%>` exported as a [Node.js](http://nodejs.org/)/[io.js](https://iojs.org/) module.
+
+## Installation
+
+Using npm:
+
+```bash
+$ {sudo -H} npm i -g npm
+$ npm i --save marionette.toolkit.<%=entryName%>
+```
+
+In Node.js/io.js:
+
+```js
+var <%=exportVarName%> = require('marionette.toolkit.<%=entryName%>');
+```
+
+See the [documentation](https://github.com/RoundingWellOS/marionette.toolkit/blob/master/README.md) for more details.

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "marionette.toolkit.<%=entryName%>",
+  "version": "<%=version%>",
+  "description": "Marionette.Toolkit’s `<%=exportVarName%>` as a module.",
+  "main": "./<%=exportVarName%>.js",
+  "keywords": [
+    "backbone.marionette",
+    "marionette",
+    "marionettejs",
+    "backbone",
+    "backbonejs",
+    "toolkit",
+    "marionette.toolkit-modularized"
+  ],
+  "author": "Paul Falgout <paul@otterball.com>",
+  "license": "MIT",
+  "repository": "RoundingWellOS/marionette.toolkit",
+  "dependencies": <%=dependencies%>
+}


### PR DESCRIPTION
Resolves #104 

This will require an `npm i`
Afterwards running `gulp build` should build a separate folder for each module under packages.
For the build we should sanity check the readme, package, and js files for the modules..
Then each package will need to be published to npm.  
Otherwise the build process should not change.