### PR TITLE
Default options style change

### DIFF
--- a/src/abstract-app.js
+++ b/src/abstract-app.js
@@ -73,7 +73,7 @@ var AbstractApp = StateClass.extend({
    * @param {Boolean} [options.preventDestroy]
    */
   constructor: function(options) {
-    options = options || {};
+    options = _.extend({}, options);
 
     _.bindAll(this, 'start', 'stop');
 

--- a/src/app.js
+++ b/src/app.js
@@ -30,7 +30,7 @@ var App = AbstractApp.extend({
    * ```
    */
   constructor: function(options) {
-    options = options || {};
+    options = _.extend({}, options);
 
     this._childApps = {};
 
@@ -320,7 +320,7 @@ var App = AbstractApp.extend({
    * @returns {App}
    */
   removeChildApp: function(appName, options) {
-    options = options || {};
+    options = _.extend({}, options);
 
     var childApp = this.getChildApp(appName);
 

--- a/src/component.js
+++ b/src/component.js
@@ -48,7 +48,7 @@ var Component = StateClass.extend({
    * @param {Marionette.Region} [options.region] - The region to show the component in.
    */
   constructor: function(stateAttrs, options){
-    options = options || {};
+    options = _.extend({}, options);
 
     // Make defaults available to this
     _.extend(this, _.pick(options, ['viewEventPrefix', 'ViewClass', 'viewOptions', 'region']));
@@ -153,7 +153,7 @@ var Component = StateClass.extend({
    * @returns {View}
    */
   _getViewClass: function(options) {
-    options = options || {};
+    options = _.extend({}, options);
 
     var ViewClass = this.getOption('ViewClass');
 

--- a/src/state-class.js
+++ b/src/state-class.js
@@ -27,7 +27,7 @@ var StateClass = Marionette.Object.extend({
    * @param {Backbone.Model} [options.StateModel] - Model class for _stateModel.
    */
   constructor: function(options){
-    options = options || {};
+    options = _.extend({}, options);
 
     // Make defaults available to this
     _.extend(this, _.pick(options, ['StateModel', 'stateEvents', 'stateDefaults']));


### PR DESCRIPTION
Backbone is changing their styles from
```js
options = options || {};
```
to
```js
options = _.extend({}, options);
```
This newer style is safer for contributors, particularly when addressing defaults so that you get
```js
options = _.extend({ foo: 'bar' }, options);
```
vs
```js
options = options || {};
if(!options.foo) options.foo = 'bar';
```
particularly to make sure defaults go at the top at not buried in the function somewhere.  Ref# https://github.com/jashkenas/backbone/pull/3629/files#diff-0d56d0d310de7ff18b3cef9c2f8f75dcL613