### PR TITLE
WIP Improve App/View relation and introduce setView

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -22,12 +22,16 @@
 * [Lifecycle Events](#lifecycle-events)
   * ["before:start" / "start" events](#beforestart--start-events)
   * ["before:stop" / "stop" events](#beforestop--stop-events)
-* [Application Region](#application-region)
-  * [App `setRegion`](#app-setregion)
 * [Application State](#application-state)
   * [App `StateModel`](#app-statemodel)
   * [App `stateEvents`](#app-stateevents)
+* [Application Region](#application-region)
+  * [App `setRegion`](#app-setregion)
+  * [App `getRegion`](#app-getregion)
 * [Application View](#application-view)
+  * [App `setView`](#application-setview)
+  * [App `getView`](#application-getview)
+  * [App `showView`](#application-showview)
   * [App `showChildView`](#app-showchildview)
   * [App `getChildView`](#app-getchildview)
 
@@ -375,19 +379,6 @@ myApp.on('stop', function(options){
 });
 ```
 
-## Application Region
-
-A `Marionette.Region` instance can be passed to [App `start`](#app-start) as an option,
-[setting the App region](#app-setregion), making it available to both [`before:start` and `start`](#beforestart--start-events) events.
-
-### App `setRegion`
-
-Calling `setRegion` will replace the `App`'s region making it available to the App's [Region API](https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.application.md#getregion).
-
-## Application State
-
-Application state can be passed to [App `start`](#app-start) as an option. The state is maintained while the app is running.
-
 ### App `StateModel`
 
 A [`StateModel`](./mixins/state.md#statemixins-statemodel) class can be passed to App instantiation as an option or defined on the App.
@@ -413,9 +404,32 @@ var MyApp = Marionette.Toolkit.App.extend({
 });
 ```
 
+## Application State
+
+Application state can be passed to [App `start`](#app-start) as an option. The state is maintained while the app is running.
+
+## Application Region
+
+A `Marionette.Region` instance can be passed to [App `start`](#app-start) as an option,
+[setting the App region](#app-setregion), making it available to both [`before:start` and `start`](#beforestart--start-events) events.
+
+### App `setRegion`
+
+Calling `setRegion` will replace the `App`'s region making it available to the App's [Region API](https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.application.md#getregion).
+
+### App `getRegion`
+
+
+
 ## Application View
 
 A [`Marionette.Application`](https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.application.md) can have an associated view shown in its region with `showView`. Toolkit takes this a step further and proxies that view's `showChildView` and `getChildView`. This is simply sugar for common patterns.
+
+### App `setView`
+
+### App `getView`
+
+### App `showView`
 
 ### App `showChildView`
 

--- a/src/app.js
+++ b/src/app.js
@@ -144,7 +144,13 @@ const App = Marionette.Application.extend({
       return this;
     }
 
-    this.setRegion(options.region);
+    if(options.region) {
+      this.setRegion(options.region);
+    }
+
+    if(options.view) {
+      this.setView(options.view);
+    }
 
     this._initState(options);
 
@@ -175,26 +181,6 @@ const App = Marionette.Application.extend({
     this._isRestarting = true;
     this.stop().start({ state });
     this._isRestarting = false;
-
-    return this;
-  },
-
-  /**
-   * Set the Application's Region after instantiation
-   *
-   * @public
-   * @method setRegion
-   * @memberOf App
-   * @param {Region} [region] - Region to use with the app
-   * @returns {App}
-   */
-
-  setRegion(region) {
-    if(!region) {
-      return this;
-    }
-
-    this._region = region;
 
     return this;
   },
@@ -259,7 +245,90 @@ const App = Marionette.Application.extend({
 
     this.stop();
 
+    delete this._view;
+
     Marionette.Object.prototype.destroy.apply(this, arguments);
+  },
+
+  /**
+   * Set the Application's Region
+   *
+   * @public
+   * @method setRegion
+   * @memberOf App
+   * @param {Region} [region] - Region to use with the app
+   * @returns {Region}
+   */
+  setRegion(region) {
+    this._region = region;
+
+    return region;
+  },
+
+  /**
+   * Get the Application's Region or
+   * Get a region from the Application's View
+   *
+   * @public
+   * @method getRegion
+   * @memberOf App
+   * @param {String} [regionName] - Optional regionName to get from the view
+   * @returns {Region}
+   */
+  getRegion(regionName) {
+    if(!regionName) {
+      return this._region;
+    }
+
+    return this.getView().getRegion(regionName);
+  },
+
+  /**
+   * Set the Application's View
+   *
+   * @public
+   * @method setView
+   * @memberOf App
+   * @param {View} [view] - View to use with the app
+   * @returns {View}
+   */
+  setView(view) {
+    this._view = view;
+
+    return view;
+  },
+
+  /**
+   * Get the Application's View
+   *
+   * @public
+   * @method getView
+   * @memberOf App
+   * @returns {View}
+   */
+  getView() {
+    const region = this.getRegion();
+
+    if(region && region.currentView) {
+      return region.currentView;
+    }
+
+    return this._view;
+  },
+
+  /**
+   * Shows a view in the Application's region
+   *
+   * @public
+   * @method showView
+   * @param {View} view - Child view instance defaults to App's view
+   * @param {...args} Additional args that get passed along
+   * @returns {View}
+   */
+  showView(view = this._view, ...args) {
+    this.getRegion().show(view, ...args);
+
+    return view;
   },
 
   /**
@@ -273,13 +342,7 @@ const App = Marionette.Application.extend({
    * @returns {View} - Child view instance
    */
   showChildView(regionName, view, ...args) {
-    const appView = this.getView();
-
-    if(!appView) {
-      return false;
-    }
-
-    appView.showChildView(regionName, view, ...args);
+    this.getView().showChildView(regionName, view, ...args);
 
     return view;
   },
@@ -293,13 +356,7 @@ const App = Marionette.Application.extend({
    * @returns {View}
    */
   getChildView(regionName) {
-    const appView = this.getView();
-
-    if(!appView) {
-      return false;
-    }
-
-    return appView.getChildView(regionName);
+    return this.getView().getChildView(regionName);
   }
 });
 


### PR DESCRIPTION
Resolves #188

This also allows for some of the methods to error naturally instead of failing silently.

```js
onBeforeStart() {
  var view = this.setView(new Layout());
  view.render();  // This line will be unnecessary in Mn v3.3
  this.showChildView('header', new HeaderView());
  this.startChildApp('main', { region: this.getRegion('main') });
  // Single DOM render
  this.showView();
}

// Instead of
onBeforeStart() {
  // DOM render
  this.showView(new Layout());
  // DOM render
  this.showChildView('header', new HeaderView());
  // At least 1 DOM render
  this.startChildApp('main', { region: this.getRegion('main') });
}
```

TODO:
- [ ] docs
- [ ] new tests / update tests for breaking changes

Thoughts?