### PR TITLE
Improve App/View relation and add ViewEventMixin

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -5,6 +5,7 @@
 * [`StateMixin`](./mixins/state.md) to maintain application state.
 * [`EventListenersMixin`](./mixins/event-listeners.md) to bind all events to an `App` while running (and only those) will be remove when stopped.
 * [`ChildAppsMixin`](./mixins/child-apps.md) to manage the addition and removal of child `App`s and relating the child `App` lifecycle with the parent `App` lifecycle.
+* [`ViewEventsMixin`](./mixins/view-events.md) for proxying events from the app's view to the app.
 
 ## Documentation Index
 * [Using Toolkit App](#using-toolkit-app)
@@ -34,6 +35,7 @@
   * [App `showView`](#application-showview)
   * [App `showChildView`](#app-showchildview)
   * [App `getChildView`](#app-getchildview)
+  * [View Events](#view-events)
 
 ## Using Toolkit App
 
@@ -605,3 +607,12 @@ myApp.getChildView('fooRegion');
 //is equivalent to
 myApp.getView().getRegion('fooRegion').currentView;
 ```
+
+### View events
+
+View events for an App's view can be proxied following a very similar API to what you would
+expect on a `Marionette.View` and `Marionette.CollectionView` with their children.
+
+You can use `viewEvents`, `viewTriggers` and `viewEventPrefix` for auto-proxying events.
+
+For more information see the [ViewEventsMixin documentation](./mixins/view-events.md).

--- a/docs/component.md
+++ b/docs/component.md
@@ -1,18 +1,21 @@
 # Marionette.Toolkit.Component
 
-`Marionette.Toolkit.Component` is heavily influenced by **@jfairbank**'s [Marionette.Component](https://github.com/jfairbank/marionette.component) and is an extension of `Marionette.Application`. It mixes in [`StateMixin`](./mixins/state.md) that manages a view (or views) whose lifecycle is tied to the region it is shown in.
+`Marionette.Toolkit.Component` is heavily influenced by **@jfairbank**'s [Marionette.Component](https://github.com/jfairbank/marionette.component) and is an extension of `Marionette.Application`.
 The Component provides a consistent interface for which to package state-view-logic.
+It utilizes the following mixins:
+
+* [`StateMixin`](./mixins/state.md) manages a view (or views) whose lifecycle is tied to the region it is shown in.
+* [`ViewEventsMixin`](./mixins/view-events.md) for proxying events from the component's view to the app.
 
 ## Documentation Index
 * [Using a Component](#using-a-component)
 * [Component's `ViewClass`](#components-viewclass)
-  * [Component's `viewEventPrefix`](#components-vieweventprefix)
   * [Component's `viewOptions`](#components-viewoptions)
 * [Component's `region`](#components-region)
 * [Component Events](#component-events)
   * ["before:show" / "show" events](#beforeshow--show-events)
   * ["before:render:view" / "render:view" events](#beforerenderview--renderview-events)
-  * ["view:*" event bubbling from the component view](#view-event-bubbling-from-the-component-view)
+  * [View Events](#view-events)
 * [Component API](#component-api)
   * [Component `showIn`](#component-showin)
   * [Component `show`](#component-show)
@@ -98,32 +101,6 @@ Marionette.Toolkit.Component.extend({
   ViewClass: MyViewClass
 });
 ```
-
-### Component's `viewEventPrefix`
-
-You can customize the event prefix for events that are forwarded
-through the component. To do this, set the `viewEventPrefix`
-on the component. For more information on the `viewEventPrefix` see
-["view:*" event bubbling from the component view](#view-event-bubbling-from-the-component-view)
-
-```js
-var MyComponent = Marionette.Toolkit.Component.extend({
-  viewEventPrefix: 'some:prefix'
-});
-
-var myComponent = new MyComponent({});
-
-myComponent.showIn(MyRegion);
-
-myComponent.on('some:prefix:render', function(){
-  // view was rendered
-});
-
-myComponent.currentView.render();
-```
-
-The `viewEventPrefix` can be provided in the component definition or
-in the constructor function call, to get a component instance.
 
 ### Component's `viewOptions`
 
@@ -240,39 +217,14 @@ myComponent.on('render:view', function(currentView){
 });
 ```
 
-### `view:*` event bubbling from the component view
+### View Events
 
-When the current view within a component triggers an
-event, that event will bubble up through the component
-with "view:" prepended to the event name.  Override the
-prefix by setting [`viewEventPrefix`](#components-vieweventprefix).
+View events for a Component's view can be proxied following a very similar API to what you would
+expect on a `Marionette.View` and `Marionette.CollectionView` with their children.
 
-That is, if a current view triggers "do:something", the
-component will then trigger "childview:do:something".
+You can use `viewEvents`, `viewTriggers` and `viewEventPrefix` for auto-proxying events.
 
-```js
-var MyView = Marionette.View.extend({
-  triggers: {
-    'click button': 'do:something'
-  }
-});
-
-// get the collection view in place
-var myComponent = new Marionette.Toolkit.Component(null, {
-  ViewClass: MyView,
-
-  onViewDoSomething: function(currentView, args*) {
-    console.log("I said, 'do something!'");
-  }
-});
-
-myComponent.on('view:do:something', function(currentView, args*){
-  console.log("My component said, 'do something!'");
-});
-```
-
-Now, whenever the button inside the `currentView` is clicked,
-both messages will log to the console.
+For more information see the [ViewEventsMixin documentation](./mixins/view-events.md).
 
 ## Component API
 

--- a/docs/mixins/view-events.md
+++ b/docs/mixins/view-events.md
@@ -1,0 +1,172 @@
+# ViewEventsMixin
+
+`ViewEventsMixin` is a private mixin for [`App`](../app.md) and [`Component`](../component.md).
+It allows the view's events to be handled by its parent.
+
+## Documentation Index
+
+* [Explicit View Event Listeners](#explicit-view-event-listeners)
+  * [Attaching Functions](#attaching-functions)
+* [Triggering Events on View Events](#triggering-events-on-view-events)
+* [`viewEventPrefix`](#vieweventprefix)
+* ["view:*" event bubbling from the app and component view](#view-event-bubbling-from-the-app-and-component-view)
+
+### Explicit View Event Listeners
+
+To call specific functions on event triggers, use the `viewEvents`
+attribute to map view events to methods on the app or component.
+
+```js
+const MyView = Mn.View.extend({
+  triggers: {
+    'click': 'click:view'
+  }
+});
+
+const MyApp = Toolkit.App.extend({
+  region: '#app-hook',
+
+  viewEvents: {
+    'click:view': 'stop'
+  },
+
+  onStart() {
+    this.showView();
+  },
+
+  onStop() {
+    console.log('MyApp was stopped');
+  }
+});
+
+const myApp = new MyApp();
+
+myApp.start{ view: new MyView() }();
+```
+
+#### Attaching Functions
+
+The `viewEvents` attribute can also attach functions directly to be event
+handlers:
+
+```js
+viewEvents: {
+  'click:view'(view) {
+     console.log(`View ${ view.cid } stopped the app!');
+     this.stop();
+  }
+},
+
+```
+
+### Triggering Events on View Events
+
+A `viewTriggers` hash or method permits proxying of view events without manually
+setting bindings. The values of the hash should be a string of the event to trigger on the app or component.
+
+`viewTriggers` is sugar on top of [`viewEvents`](#explicit-view-event-listeners) much
+in the same way that [View `triggers`](https://github.com/marionettejs/backbone.marionette/blob/v3.2.0/docs/marionette.view.md#view-triggers)
+are sugar for [View `events`](https://github.com/marionettejs/backbone.marionette/blob/v3.2.0/docs/marionette.view.md#view-events).
+
+```js
+// The view fires a custom event, `foo:event`
+const ComponentView = Marionette.View.extend({
+
+  // Events hash defines local event handlers that in turn may call `triggerMethod`.
+  events: {
+    'click .button': 'onClickButton'
+  },
+
+  triggers: {
+    'submit form': 'submit:form'
+  },
+
+  onClickButton: function () {
+    // Both `trigger` and `triggerMethod` events will be caught by the component.
+    this.trigger('foo:event', 'foo');
+    this.triggerMethod('foo:event', 'bar');
+  }
+});
+
+// The component uses viewEvents to catch the view's custom event
+const MyComponent = Toolkit.Component.extend({
+  ViewClass: ComponentView,
+
+  viewTriggers: {
+    'foo:event': 'view:foo:event',
+    'submit:form': 'view:submit:form'
+  },
+
+  onViewFooEvent: function (message) {
+    console.log('A view fired foo:event with ' + message);
+  },
+
+  onViewSubmitForm: function (view) {
+    console.log('A view fired submit:form');
+  }
+});
+```
+
+### `viewEventPrefix`
+
+`viewEventPrefix` is `false` by default.
+
+You can customize the event prefix for events that are forwarded
+through the app or component. To do this, set the `viewEventPrefix`.
+For more information on the `viewEventPrefix` see
+["view:*" event bubbling from the app and component view](#view-event-bubbling-from-the-app-and-component-view)
+
+```js
+const MyApp = Toolkit.App.extend({
+  viewEventPrefix: 'some:prefix'
+});
+
+const myApp = new MyApp();
+
+myApp.start({ view: new MyView() });
+
+myApp.on('some:prefix:render', function(){
+  // view was rendered
+});
+
+// view will be rendered on show
+myApp.showView();
+```
+
+The `viewEventPrefix` can be provided in the app or component definition or
+by passing as an option when instantiating an instance.
+
+### `view:*` event bubbling from the app and component view
+
+When the current view within a component or app triggers an event, if the app or component
+has a defined [`viewEventPrefix`](#vieweventprefix) that event will bubble up through
+the component with the `viewEventPrefix` prepended to the event name.  Override
+the prefix by setting `viewEventPrefix`.
+
+That is if a view has a `viewEventPrefix` of "view", when a current view triggers "event:name",
+the app or component will then trigger "view:event:name" on itself.
+
+```js
+const MyView = Marionette.View.extend({
+  triggers: {
+    'click button': 'click:button'
+  }
+});
+
+// get the collection view in place
+const myComponent = new Toolkit.Component(null, {
+  viewEventPrefix: 'view',
+
+  ViewClass: MyView,
+
+  onViewClickButton: function(view, ...args) {
+    console.log('I said, "button clicked!"');
+  }
+});
+
+myComponent.on('view:click:button', function(view, ...args){
+  console.log("My component said, 'button clicked!'");
+});
+```
+
+Now, whenever the button inside the view is clicked, both messages will log to the console.

--- a/src/app.js
+++ b/src/app.js
@@ -77,6 +77,7 @@ const App = Marionette.Application.extend({
   constructor(options = {}) {
     this.mergeOptions(options, ClassOptions);
 
+    // ChildAppsMixin
     this._initChildApps(options);
 
     Marionette.Application.call(this, options);
@@ -146,12 +147,14 @@ const App = Marionette.Application.extend({
 
     this.setRegion(options.region);
 
+    // StateMixin
     this._initState(options);
 
     this.triggerMethod('before:start', options);
 
     this._isRunning = true;
 
+    // StateMixin
     this.delegateStateEvents();
 
     this.triggerStart(options);
@@ -254,12 +257,14 @@ const App = Marionette.Application.extend({
    */
   destroy() {
     if(this._isDestroyed) {
-      return;
+      return this;
     }
 
     this.stop();
 
     Marionette.Object.prototype.destroy.apply(this, arguments);
+
+    return this;
   },
 
   /**

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ import Marionette from 'backbone.marionette';
 import StateMixin from './mixins/state';
 import ChildAppsMixin from './mixins/child-apps';
 import EventListenersMixin from './mixins/event-listeners';
+import ViewEventsMixin from './mixins/view-events';
 
 const ClassOptions = [
   'startWithParent',
@@ -10,7 +11,10 @@ const ClassOptions = [
   'startAfterInitialized',
   'preventDestroy',
   'StateModel',
-  'stateEvents'
+  'stateEvents',
+  'viewEventPrefix',
+  'viewEvents',
+  'viewTriggers'
 ];
 
 /**
@@ -76,6 +80,11 @@ const App = Marionette.Application.extend({
    */
   constructor(options = {}) {
     this.mergeOptions(options, ClassOptions);
+
+    this.options = _.extend({}, _.result(this, 'options'), options);
+
+    // ViewEventMixin
+    this._buildEventProxies();
 
     // ChildAppsMixin
     this._initChildApps(options);
@@ -350,6 +359,9 @@ const App = Marionette.Application.extend({
 
     this._view = view;
 
+    // ViewEventsMixin
+    this._proxyViewEvents(view);
+
     return view;
   },
 
@@ -409,6 +421,6 @@ const App = Marionette.Application.extend({
   }
 });
 
-_.extend(App.prototype, StateMixin, ChildAppsMixin, EventListenersMixin);
+_.extend(App.prototype, StateMixin, ChildAppsMixin, EventListenersMixin, ViewEventsMixin);
 
 export default App;

--- a/src/component.js
+++ b/src/component.js
@@ -9,6 +9,7 @@ const ClassOptions = [
   'viewOptions',
   'region'
 ];
+
 /**
  * Reusable Marionette.Object with View management boilerplate
  *
@@ -57,10 +58,12 @@ const Component = Marionette.Object.extend({
     // Make defaults available to this
     this.mergeOptions(options, ClassOptions);
 
+    // StateMixin
     this._initState(options);
 
     Marionette.Object.call(this, options);
 
+    // StateMixin
     this.delegateStateEvents();
   },
 
@@ -315,6 +318,8 @@ const Component = Marionette.Object.extend({
     this._shouldDestroy = true;
 
     this._destroy(options);
+
+    return this;
   }
 });
 

--- a/src/mixins/state.js
+++ b/src/mixins/state.js
@@ -32,6 +32,8 @@ export default {
   initState(options = {}) {
     this._initState(options);
     this.delegateStateEvents();
+
+    return this;
   },
 
   /**
@@ -51,8 +53,6 @@ export default {
     this._stateModel = new StateModel(options.state);
 
     this._setEventHandlers();
-
-    return this;
   },
 
   /**

--- a/src/mixins/view-events.js
+++ b/src/mixins/view-events.js
@@ -1,0 +1,69 @@
+export default {
+  /**
+   * Used as the prefix for events forwarded from
+   * the component's view to the component
+   * @type {String}
+   * @default false
+   */
+  viewEventPrefix: false,
+
+  /**
+   * Constructs hashes and options for view event proxy
+   *
+   * @private
+   * @method _buildEventProxies
+   */
+  _buildEventProxies() {
+    const viewEvents = _.result(this, 'viewEvents') || {};
+    this._viewEvents = this.normalizeMethods(viewEvents);
+    this._viewTriggers = _.result(this, 'viewTriggers') || {};
+    this._viewEventPrefix = _.result(this, 'viewEventPrefix');
+  },
+
+  /**
+   * Proxies the ViewClass's viewEvents to the Component itself
+   * Similar to CollectionView childEvents
+   * (http://marionettejs.com/docs/v2.3.2/marionette.collectionview.html#collectionviews-childevents)
+   *
+   * @private
+   * @method _proxyViewEvents
+   * @param {Mn.View|Mn.CollectionView} view -
+   * The instantiated ViewClass.
+   */
+  _proxyViewEvents(view) {
+    this.listenTo(view, 'all', this._childViewEventHandler);
+  },
+
+  /**
+   * Event handler for view proxy
+   * Similar to CollectionView childEvents
+   * (http://marionettejs.com/docs/v2.3.2/marionette.collectionview.html#collectionviews-childevents)
+   *
+   * @private
+   * @method _childViewEventHandler
+   * @param {String} - event name
+   */
+  _childViewEventHandler(eventName, ...args) {
+    const viewEvents = this._viewEvents;
+
+    if(_.isFunction(viewEvents[eventName])) {
+      viewEvents[eventName].apply(this, args);
+    }
+
+    // use the parent view's proxyEvent handlers
+    const viewTriggers = this._viewTriggers;
+
+    // Call the event with the proxy name on the parent layout
+    if(_.isString(viewTriggers[eventName])) {
+      this.triggerMethod(viewTriggers[eventName], ...args);
+    }
+
+    const prefix = this._viewEventPrefix;
+
+    if(prefix !== false) {
+      const viewEventName = `${ prefix }:${ eventName }`;
+
+      this.triggerMethod(viewEventName, ...args);
+    }
+  }
+};

--- a/test/unit/component.spec.js
+++ b/test/unit/component.spec.js
@@ -211,27 +211,6 @@ describe('Marionette.Toolkit.Component', function() {
       });
     });
 
-    describe('with a customized viewEventPrefix', function() {
-      it('should trigger the correct action as defined', function() {
-        this.MyComponent = Marionette.Toolkit.Component.extend({
-          viewEventPrefix: 'some:prefix',
-          viewOptions: {
-            template: false
-          },
-          testRender: false
-        });
-        this.myComponent = new this.MyComponent({});
-
-        this.myComponent.showIn(this.myRegion);
-        this.myComponent.on('some:prefix:render', function() {
-          this.testRender = true;
-        });
-        this.myComponent.currentView.render();
-
-        expect(this.myComponent.testRender).to.equal(true);
-      });
-    });
-
     describe('with defined viewOptions', function() {
       beforeEach(function() {
         this.MyView = Marionette.View.extend({

--- a/test/unit/mixins/view-events.spec.js
+++ b/test/unit/mixins/view-events.spec.js
@@ -1,0 +1,194 @@
+import _ from 'underscore';
+
+describe('ViewEventsMixin', function() {
+  const mergeOptions = {
+    viewEventPrefix: 'child',
+    viewEvents: {},
+    viewTriggers: {}
+  };
+
+  let myRegion;
+
+  beforeEach(function() {
+    this.setFixtures('<div id="testRegion"></div>');
+    myRegion = new Marionette.Region({
+      el: Backbone.$('#testRegion')
+    });
+  });
+
+  describe('when initializing an app', function() {
+    let myApp;
+
+    beforeEach(function() {
+      const MyApp = Marionette.Toolkit.App.extend();
+      this.sinon.spy(MyApp.prototype, '_buildEventProxies');
+      myApp = new MyApp(mergeOptions);
+    });
+
+    _.each(mergeOptions, function(value, key) {
+      it(`should merge ViewEventsMixin option ${ key }`, function() {
+        expect(myApp[key]).to.equal(value);
+      });
+    });
+
+    it('should build event proxies', function() {
+      expect(myApp._buildEventProxies).to.have.been.calledOnce;
+    });
+  });
+
+  describe('when initializing a component', function() {
+    let myComponent;
+
+    beforeEach(function() {
+      const MyComponent = Marionette.Toolkit.Component.extend();
+      this.sinon.spy(MyComponent.prototype, '_buildEventProxies');
+      myComponent = new MyComponent(mergeOptions);
+    });
+
+    _.each(mergeOptions, function(value, key) {
+      it(`should merge ViewEventsMixin option ${ key }`, function() {
+        expect(myComponent[key]).to.equal(value);
+      });
+    });
+
+    it('should build event proxies', function() {
+      expect(myComponent._buildEventProxies).to.have.been.calledOnce;
+    });
+  });
+
+  describe('when a view is set to an app', function() {
+    it('should proxy view events', function() {
+      const myApp = new Marionette.Toolkit.App();
+      this.sinon.spy(myApp, '_proxyViewEvents');
+
+      const myView = new Marionette.View();
+      myApp.setView(myView);
+
+      expect(myApp._proxyViewEvents)
+        .to.have.been.calledOnce.and.calledWith(myView);
+    });
+  });
+
+  describe('when a view is rendered on a component', function() {
+    it('should proxy view events', function() {
+      const myComponent = new Marionette.Toolkit.Component({
+        viewOptions: {
+          template: _.template('foo')
+        }
+      });
+      this.sinon.spy(myComponent, '_proxyViewEvents');
+
+      myComponent.showIn(myRegion);
+
+
+      expect(myComponent._proxyViewEvents)
+        .to.have.been.calledOnce.and.calledWith(myComponent.currentView);
+    });
+  });
+
+  describe('viewEventPrefix', function() {
+    describe('when viewEventPrefix is left false', function() {
+      it('should not trigger the action', function() {
+        const handlerStub = this.sinon.stub();
+
+        const MyComponent = Marionette.Toolkit.Component.extend({
+          viewOptions: {
+            template: _.noop
+          }
+        });
+        const myComponent = new MyComponent();
+
+        myComponent.showIn(myRegion);
+        myComponent.on('some:prefix:render', handlerStub);
+        myComponent.currentView.render();
+
+        expect(handlerStub).to.not.have.been.called;
+      });
+    });
+
+    describe('when defining a viewEventPrefix', function() {
+      it('should trigger the correct action as defined', function() {
+        const handlerStub = this.sinon.stub();
+
+        const MyComponent = Marionette.Toolkit.Component.extend({
+          viewEventPrefix: 'some:prefix',
+          viewOptions: {
+            template: _.noop
+          }
+        });
+        const myComponent = new MyComponent();
+
+        myComponent.showIn(myRegion);
+        myComponent.on('some:prefix:render', handlerStub);
+        myComponent.currentView.render();
+
+        expect(handlerStub).to.have.been.calledOnce;
+      });
+    });
+  });
+
+  describe('viewEvents', function() {
+    let fooStub;
+    let barStub;
+    let myView;
+
+    beforeEach(function() {
+      fooStub = this.sinon.stub();
+      barStub = this.sinon.stub();
+
+      const MyApp = Marionette.Toolkit.App.extend({
+        viewEvents: {
+          'foo': fooStub,
+          'bar': 'onBarStub'
+        },
+        onBarStub: barStub
+      });
+
+      const myApp = new MyApp();
+      myView = new Marionette.View();
+
+      myApp.setView(myView);
+    });
+
+    it('should trigger view events to a function handle', function() {
+      const args = {};
+      myView.trigger('foo', args);
+      expect(fooStub).to.have.been.calledOnce.and.calledWith(args);
+    });
+
+    it('should trigger view events to a named handle', function() {
+      const args = {};
+      myView.trigger('bar', args);
+      expect(barStub).to.have.been.calledOnce.and.calledWith(args);
+    });
+  });
+
+  describe('viewTriggers', function() {
+    let fooStub;
+    let myView;
+
+    beforeEach(function() {
+      fooStub = this.sinon.stub();
+
+      const MyApp = Marionette.Toolkit.App.extend({
+        viewTriggers: {
+          'foo': 'foo'
+        }
+      });
+
+      const myApp = new MyApp();
+
+      myApp.on('foo', fooStub);
+
+      myView = new Marionette.View();
+
+      myApp.setView(myView);
+    });
+
+    it('should trigger view events to a event on the app', function() {
+      const args = {};
+      myView.trigger('foo', args);
+      expect(fooStub).to.have.been.calledOnce.and.calledWith(args);
+    });
+  });
+});


### PR DESCRIPTION
Resolves #208 #188 

This is a WIP.  I still need to:
- [x] Test `ViewEventMixin` and implementation
- [x] Document [`ViewEventMixin`](https://github.com/paulfalgout/marionette.toolkit/blob/feature/view-event-mixin/docs/mixins/view-events.md)

I think for me this will finalize the v4.0 needs unless something else comes up.

Includes https://github.com/RoundingWellOS/marionette.toolkit/pull/207

It also adds the ViewEventMixin which affects both the App, improves upon #207 and the Component.

This makes the view event API more consistent with Marionette.

Notable breaking changes are that components will no longer auto-proxy events with the `view:` prefix.  For components wishing to proxy all events, they'll need to add `viewEventPrefix: 'view'`

Additionally the `view` instance is not longer prepended to the proxied view events.  This change aligns with the Marionette v3 `childViewEventPrefix` changes.
