### PR TITLE
expose component show for overriding

### DIFF
--- a/docs/component.md
+++ b/docs/component.md
@@ -21,6 +21,7 @@ It utilizes the following mixins:
   * [Component `show`](#component-show)
   * [Component `renderView`](#component-renderview)
   * [Component `currentView`](#component-currentview)
+  * [Component `showView`](#component-showview)
   * [Component `mixinOptions`](#component-mixinoptions)
   * [Component `buildView`](#component-buildview)
   * [Component `destroy`](#component-destroy)
@@ -266,8 +267,7 @@ myComponent.show(viewOptions);
 ### Component `renderView`
 
 Builds the view from the ViewClass with the options from [`mixinOptions`](#component-mixinoptions)
-and attaches it to the component's `currentView`. It then shows the `currentView` in the component's `region`.
-During this `region.show` the component will not destroy itself on the region's empty event.
+and attaches it to the component's `currentView`. It then shows the `currentView` in the component's `region` via `showView`.
 While a component can only be shown once, it can be re-rendered many times.
 `renderView` triggers ["before:render:view" / "render:view" events](#beforerenderview--renderview-events).
 
@@ -310,6 +310,29 @@ myComponent.show({
 
 // Works but best to use the component to interface with the view.
 var view = myComponent.currentView;
+```
+
+### Component `showView`
+
+Shows the `view` in the component's `region`.
+During this `region.show` the component will not destroy itself on the region's empty event.
+This method can be overridden to change a component's behavior and should not be called directly.
+
+```js
+var MyComponent = Marionette.Toolkit.Component.extend({
+  ViewClass: MyViewClass,
+  region: someRegion,
+  showView(view) {
+    this.getRegion().show(view, { replaceElement: true });
+  }
+});
+
+var myComponent = new MyComponent();
+
+// region el is now <div class="my-component-class">
+myComponent.renderView({
+  className: 'my-component-class'
+});
 ```
 
 ### Component `mixinOptions`

--- a/docs/component.md
+++ b/docs/component.md
@@ -268,6 +268,7 @@ myComponent.show(viewOptions);
 
 Builds the view from the ViewClass with the options from [`mixinOptions`](#component-mixinoptions)
 and attaches it to the component's `currentView`. It then shows the `currentView` in the component's `region` via `showView`.
+During this `region.show` the component will not destroy itself on the region's empty event.
 While a component can only be shown once, it can be re-rendered many times.
 `renderView` triggers ["before:render:view" / "render:view" events](#beforerenderview--renderview-events).
 
@@ -314,9 +315,8 @@ var view = myComponent.currentView;
 
 ### Component `showView`
 
-Shows the `view` in the component's `region`.
-During this `region.show` the component will not destroy itself on the region's empty event.
-This method can be overridden to change a component's behavior and should not be called directly.
+Called by `renderView`, it shows the `view` in the component's `region`.
+This method can be overridden to change a component's behavior.
 
 ```js
 var MyComponent = Marionette.Toolkit.Component.extend({

--- a/src/component.js
+++ b/src/component.js
@@ -200,14 +200,26 @@ const Component = Marionette.Object.extend({
     // destroyed if the region is emptied by Component itself.
     this._shouldDestroy = false;
 
-    // Show the view in the region
-    this.getRegion().show(view);
+    this.showView(view);
 
     this._shouldDestroy = true;
 
     this.triggerMethod('render:view', view);
 
     return this;
+  },
+
+  /**
+   * Override this to change how the component's view is shown in the region
+   *
+   * @public
+   * @method showView
+   * @memberOf Component
+   * @param {Object} view - view built from a viewClass and viewOptions
+   */
+  showView(view) {
+    // Show the view in the region
+    this.getRegion().show(view);
   },
 
   /**

--- a/test/unit/component.spec.js
+++ b/test/unit/component.spec.js
@@ -120,6 +120,14 @@ describe('Marionette.Toolkit.Component', function() {
       expect(this.renderStub).to.have.been.calledOnce;
     });
 
+    it('should call showView with the current view instance', function() {
+      this.sinon.spy(this.myComponent, 'showView');
+
+      this.myComponent.renderView();
+
+      expect(this.myComponent.showView).to.have.been.calledOnce.and.calledWith(this.myComponent.currentView);
+    });
+
     describe('and checking the currentView', function() {
       it('should have the correct className on currentView', function() {
         this.myComponent.renderView({


### PR DESCRIPTION
Why: There are options available to region.show that cannot be used by component currently.

What: Expose `this.getRegion().show(view)` with an overridable function to allow those options to be used.

How: Add `showView` function to the Component that replaces `this.getRegion().show(view)` in `renderView`.

This is mentioned in the documentation, but `showView` should never be called directly. It should only ever be overwritten for each use-case.

Coverage report:
```
------------------------|----------|----------|----------|----------|----------------|
File                    |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
------------------------|----------|----------|----------|----------|----------------|
 src/                   |      100 |      100 |      100 |      100 |                |
  app.js                |      100 |      100 |      100 |      100 |                |
  component.js          |      100 |      100 |      100 |      100 |                |
  marionette.toolkit.js |      100 |      100 |      100 |      100 |                |
 src/mixins/            |      100 |      100 |      100 |      100 |                |
  child-apps.js         |      100 |      100 |      100 |      100 |                |
  event-listeners.js    |      100 |      100 |      100 |      100 |                |
  state.js              |      100 |      100 |      100 |      100 |                |
  view-events.js        |      100 |      100 |      100 |      100 |                |
------------------------|----------|----------|----------|----------|----------------|
All files               |      100 |      100 |      100 |      100 |                |
------------------------|----------|----------|----------|----------|----------------|


=============================== Coverage summary ===============================
Statements   : 100% ( 308/308 )
Branches     : 100% ( 126/126 )
Functions    : 100% ( 78/78 )
Lines        : 100% ( 303/303 )
================================================================================
```