### PR TITLE
set _isRestarting flag to false default

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -19,6 +19,7 @@
   * [App `restart`](#app-restart)
   * [App `stop`](#app-stop)
   * [App `isRunning`](#app-isrunning)
+  * [App `isRestarting`](#app-isrestarting)
   * [App `destroy`](#app-destroy)
 * [Lifecycle Events](#lifecycle-events)
   * ["before:start" / "start" events](#beforestart--start-events)

--- a/src/app.js
+++ b/src/app.js
@@ -37,6 +37,15 @@ const App = Marionette.Application.extend({
   _isRunning: false,
 
   /**
+   * Internal flag indiciate when `App` is in the process of stopping then starting.
+   *
+   * @private
+   * @type {Boolean}
+   * @default false
+   */
+  _isRestarting: false,
+
+  /**
    * Set to true if a parent `App` should not be able to destroy this `App`.
    *
    * @type {Boolean|Function}

--- a/test/unit/app-lifecycle.spec.js
+++ b/test/unit/app-lifecycle.spec.js
@@ -112,7 +112,7 @@ describe('App-Lifecycle', function() {
     });
 
     it('should start with _isRestarting flag set to false', function() {
-      expect(this.myApp._isRestarting).to.equal(false);
+      expect(this.myApp.isRestarting()).to.equal(false);
     });
 
     it('should be stopped', function() {

--- a/test/unit/app-lifecycle.spec.js
+++ b/test/unit/app-lifecycle.spec.js
@@ -111,6 +111,10 @@ describe('App-Lifecycle', function() {
       });
     });
 
+    it('should start with _isRestarting flag set to false', function() {
+      expect(this.myApp._isRestarting).to.equal(false);
+    });
+
     it('should be stopped', function() {
       this.myApp.restart();
 


### PR DESCRIPTION
Why: `_isRestarting` is currently undefined until after the first restart.

What: Ensure that `_isRestarting` is always set to false when the app is not restarting.

How: Set the default value for `_isRestarting` to false when the app is initialized.

I've added only one test for the private key and no documentation, since it is not accessed by users.