### PR TITLE
delete listeners and view reference in region app when destroyed

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -351,7 +351,7 @@ const App = Marionette.Application.extend({
    * @method _onEmpty
    * @memberOf App
    */
-  _onEmpty(region, view) {
+  _onEmpty() {
     this._removeView();
   },
 

--- a/src/app.js
+++ b/src/app.js
@@ -290,7 +290,7 @@ const App = Marionette.Application.extend({
 
     this.stop();
 
-    delete this._view;
+    this._removeView();
 
     Marionette.Application.prototype.destroy.apply(this, arguments);
 
@@ -327,7 +327,10 @@ const App = Marionette.Application.extend({
    * @memberOf App
    */
   _regionEventMonitor() {
-    this.listenTo(this._region, 'before:show', this._onBeforeShow);
+    this.listenTo(this._region, {
+      'before:show': this._onBeforeShow,
+      'empty': this._onEmpty
+    });
   },
 
   /**
@@ -339,6 +342,31 @@ const App = Marionette.Application.extend({
    */
   _onBeforeShow(region, view) {
     this.setView(view);
+  },
+
+  /**
+   * Region monitor handler which empties the region's view
+   *
+   * @private
+   * @method _onEmpty
+   * @memberOf App
+   */
+  _onEmpty(region, view) {
+    this._removeView();
+  },
+
+  /**
+   * Region monitor handler which deletes the region's view and listeners to view
+   *
+   * @private
+   * @method _removeView
+   * @memberOf App
+   */
+  _removeView() {
+    if(this._view) {
+      this.stopListening(this._view);
+      delete this._view;
+    }
   },
 
   /**
@@ -381,6 +409,8 @@ const App = Marionette.Application.extend({
 
     // ViewEventsMixin
     this._proxyViewEvents(view);
+
+    this.listenTo(this._view, 'destroy', this._removeView);
 
     return view;
   },

--- a/test/unit/app.spec.js
+++ b/test/unit/app.spec.js
@@ -206,6 +206,42 @@ describe('App', function() {
         expect(this.myApp.getView()).to.equal(this.view);
       });
     });
+
+    describe('when a view is emptied in the app\'s region', function() {
+      it('should delete the shown view', function() {
+        this.myApp.setRegion(this.region);
+        this.myApp.showView(this.view);
+        this.myApp.getRegion().empty();
+        expect(this.myApp.getView()).to.be.undefined;
+      });
+
+      it('should remove any listeners to the view', function() {
+        this.sinon.spy(this.myApp, 'stopListening');
+
+        this.myApp.setRegion(this.region);
+        this.myApp.showView(this.view);
+        this.myApp.getRegion().empty();
+        expect(this.myApp.stopListening).to.have.been.calledWith(this.view);
+      });
+    });
+
+    describe('when a view in the app\'s region is destroyed', function() {
+      it('should delete the shown view', function() {
+        this.myApp.setRegion(this.region);
+        this.myApp.showView(this.view);
+        this.myApp.getView().destroy();
+        expect(this.myApp.getView()).to.be.undefined;
+      });
+
+      it('should remove any listeners to the view', function() {
+        this.sinon.spy(this.myApp, 'stopListening');
+
+        this.myApp.setRegion(this.region);
+        this.myApp.showView(this.view);
+        this.myApp.getView().destroy();
+        expect(this.myApp.stopListening).to.have.been.calledWith(this.view);
+      });
+    });
   });
 
   describe('#showView', function() {


### PR DESCRIPTION
Why: Destroying a region's view is not correctly deleting any references or listeners to the view.

What: Each instance of a view being destroyed needs to ensure that listeners and references are removed as well.

How: In `setView`, `_regionEventMonitor`,  and `destroy`, there is now a check to ensure `stopListening` is called on the view and that it's deleted.

Coverage Report: 
```
------------------------|----------|----------|----------|----------|----------------|
File                    |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
------------------------|----------|----------|----------|----------|----------------|
 src/                   |      100 |      100 |      100 |      100 |                |
  app.js                |      100 |      100 |      100 |      100 |                |
  component.js          |      100 |      100 |      100 |      100 |                |
  marionette.toolkit.js |      100 |      100 |      100 |      100 |                |
 src/mixins/            |      100 |      100 |      100 |      100 |                |
  child-apps.js         |      100 |      100 |      100 |      100 |                |
  event-listeners.js    |      100 |      100 |      100 |      100 |                |
  state.js              |      100 |      100 |      100 |      100 |                |
  view-events.js        |      100 |      100 |      100 |      100 |                |
------------------------|----------|----------|----------|----------|----------------|
All files               |      100 |      100 |      100 |      100 |                |
------------------------|----------|----------|----------|----------|----------------|


=============================== Coverage summary ===============================
Statements   : 100% ( 316/316 )
Branches     : 100% ( 132/132 )
Functions    : 100% ( 80/80 )
Lines        : 100% ( 311/311 )
================================================================================
```

I've written test cases for a view being emptied from the region and independently destroyed, but there might be edge cases I'm missing. Any feedback or test suggestions would be appreciated.