### PR TITLE
Move view, region, and state events to running only events

### DIFF
--- a/test/unit/app.spec.js
+++ b/test/unit/app.spec.js
@@ -90,6 +90,21 @@ describe('App', function() {
         expect(this.myApp.setRegion(region)).to.equal(region);
       });
     });
+
+    describe('when setting a region with a view', function() {
+      beforeEach(function() {
+        this.myRegion = new Marionette.Region({ el: $('<div>')[0] });
+        this.myRegion.show(new Marionette.View({ template: false }));
+
+        this.myApp = new this.MyApp();
+
+        this.myApp.setRegion(this.myRegion);
+      });
+
+      it('should set the app view to the region view', function() {
+        expect(this.myApp.getRegion().currentView).to.equal(this.myApp.getView());
+      });
+    });
   });
 
   describe('#getRegion', function() {

--- a/test/unit/mixins/view-events.spec.js
+++ b/test/unit/mixins/view-events.spec.js
@@ -16,13 +16,14 @@ describe('ViewEventsMixin', function() {
     });
   });
 
-  describe('when initializing an app', function() {
+  describe('when starting an app', function() {
     let myApp;
 
     beforeEach(function() {
       const MyApp = Marionette.Toolkit.App.extend();
       this.sinon.spy(MyApp.prototype, '_buildEventProxies');
       myApp = new MyApp(mergeOptions);
+      myApp.start();
     });
 
     _.each(mergeOptions, function(value, key) {
@@ -63,6 +64,8 @@ describe('ViewEventsMixin', function() {
 
       const myView = new Marionette.View();
       myApp.setView(myView);
+
+      myApp.start();
 
       expect(myApp._proxyViewEvents)
         .to.have.been.calledOnce.and.calledWith(myView);
@@ -148,6 +151,8 @@ describe('ViewEventsMixin', function() {
       myView = new Marionette.View();
 
       myApp.setView(myView);
+
+      myApp.start();
     });
 
     it('should trigger view events to a function handle', function() {
@@ -183,6 +188,8 @@ describe('ViewEventsMixin', function() {
       myView = new Marionette.View();
 
       myApp.setView(myView);
+
+      myApp.start();
     });
 
     it('should trigger view events to a event on the app', function() {


### PR DESCRIPTION
Resolves https://github.com/RoundingWellOS/marionette.toolkit/issues/217

This was a complicated bug that really made a breaking change necessary.

Essentially this means that as far as the app API internally is concerned, events for the region, view, and state will only occur during the run time.  There will be some management to make sure the set view or region is maintained when an app is not running so that everything is expected to work once the app is running.