### PR TITLE
Implement options in stopChildApp

### DIFF
--- a/docs/mixins/child-apps.md
+++ b/docs/mixins/child-apps.md
@@ -269,10 +269,13 @@ var childAppInstance = myApp.startChildApp('cA1');
 console.log(childAppInstance.isRunning());
 
 // This is equivalent to childAppInstance.stop();
-myApp.stopChildApp('cA1');
+myApp.stopChildApp('cA1', { foo: 'bar' });
 
 // false
 console.log(childAppInstance.isRunning());
+
+// bar
+console.log(childAppInstance.getOption('foo'));
 ```
 
 Note: The parentApp instance is returned for chaining.

--- a/src/mixins/child-apps.js
+++ b/src/mixins/child-apps.js
@@ -112,11 +112,12 @@ export default {
    * Stops `childApp`
    *
    * @param {String} appName - Name of childApp to stop
+   * @param {Object} options - Stop options for app
    * @public
    * @method stopChildApp
    */
-  stopChildApp(appName) {
-    return this.getChildApp(appName).stop();
+  stopChildApp(appName, options) {
+    return this.getChildApp(appName).stop(options);
   },
 
   /**

--- a/test/unit/mixins/child-apps.spec.js
+++ b/test/unit/mixins/child-apps.spec.js
@@ -381,6 +381,15 @@ describe('ChildAppMixin', function() {
       expect(this.myChildApp.isRunning()).to.be.false;
     });
 
+    it('should stop childApp with options', function() {
+      const spy = sinon.spy(this.myChildApp, 'stop');
+
+      this.myApp.stopChildApp('cA1', { foo: 'bar' });
+
+      expect(spy.calledWith({ foo: 'bar' })).to.be.true;
+    });
+
+
     it('should return parentApp instance', function() {
       const spy = sinon.spy(this.myApp, 'stopChildApp');
 


### PR DESCRIPTION
Why: Sometimes options need to be passed to a child app from the parent when stopping the child.

What: Ensure that calling `stopChildApp` can receive options.

How: Pass options to the child `stop` function from the `stopChildApp` parent function.

Tests and docs are present, but not perfect. Feedback would be appreciated.