### PR TITLE
Allow passing options to `app.restart()`

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -224,11 +224,11 @@ const App = Application.extend({
    * @memberOf App
    * @returns {App}
    */
-  restart() {
+  restart(options) {
     const state = this.getState().attributes;
 
     this._isRestarting = true;
-    this.stop().start({ state });
+    this.stop().start(_.extend({ state }, options));
     this._isRestarting = false;
 
     return this;

--- a/test/unit/app-lifecycle.spec.js
+++ b/test/unit/app-lifecycle.spec.js
@@ -140,6 +140,16 @@ describe('App-Lifecycle', function() {
       expect(this.beforeStartStub).to.be.calledWith({ state: { foo: 'baz' } });
     });
 
+    it('should maintain the app\'s previous state with options data', function() {
+      expect(this.beforeStartStub).to.be.calledWith({ state: { foo: 'bar' } });
+
+      this.myApp.setState('foo', 'baz');
+
+      this.myApp.restart({ options: { foo: 'bar' } });
+
+      expect(this.beforeStartStub).to.be.calledWith({state: { foo: 'baz' }, options: { foo: 'bar' }});
+    });
+
     it('should set isRestarting() during restart process', function() {
       const NewApp = App.extend({
         onBeforeStop() {


### PR DESCRIPTION
When an options object is passed, the app state and those options will be included when the app starts again.